### PR TITLE
Fix "name in use" errors from module preload script

### DIFF
--- a/monodevelop.lua
+++ b/monodevelop.lua
@@ -122,8 +122,6 @@
 		end
 	end
 
-
-	include("_preload.lua")
 	include("monodevelop_cproj.lua")
 
 	return m


### PR DESCRIPTION
The module preloaded now uses `loadfile()` rather than `include()` in order to report script errors. As a result, the `_preload.lua` file is no longer marked as included, so subsequent calls to `include("_preload.lua")` will result in duplicated symbols.
