### PR TITLE
Fix "concatenate nil value" error

### DIFF
--- a/monodevelop_cproj.lua
+++ b/monodevelop_cproj.lua
@@ -401,7 +401,11 @@
 		end
 		if #cfg.buildoptions > 0 then
 			local buildOpts = table.concat(cfg.buildoptions, " ")
-			options = iif(options, options .. " " .. buildOpts, buildOpts)
+			if options then
+				options = options .. " " .. buildOpts
+			else
+				options = buildOpts
+			end
 		end
 
 		if options then


### PR DESCRIPTION
If `options` is nil the script fails with a `attempt to concatenate local 'options' (a nil value)` when trying to construct the the second argument for `iif`.

This change fixes this. But since I'm not a LUA guy there may be better ways to fix this?
