### PR TITLE
sln2005 Update

### DIFF
--- a/monodevelop.lua
+++ b/monodevelop.lua
@@ -82,7 +82,13 @@
 		return oldfn(prj)
 	end)
 
-	sln2005.sectionmap.MonoDevelopProperties = m.MonoDevelopProperties
+	p.override(sln2005.elements, "sections", function(oldfn, wks)
+		local elements = oldfn(wks)
+		elements = table.join(elements, {
+			m.MonoDevelopProperties,
+		})
+		return elements
+	end)
 
 	p.override(vstudio, "projectfile", function(oldfn, prj)
 		if _ACTION == "monodevelop" then

--- a/tests/test_sln.lua
+++ b/tests/test_sln.lua
@@ -35,7 +35,7 @@ EndProject
 
 	function suite.monoDevelopProperties()
 		project "MyProject"
-		premake.vstudio.sln2005.sectionmap.MonoDevelopProperties(wks)
+		monodevelop.MonoDevelopProperties(wks)
 		test.capture [[
 	GlobalSection(MonoDevelopProperties) = preSolution
 	EndGlobalSection


### PR DESCRIPTION
Updated monodevelop module to use `sln2005.elements.sections` instead of `sln2005.sectionmap`.
